### PR TITLE
Added error_message poro and error serializer for sad path handling

### DIFF
--- a/app/controllers/api/v1/properties_controller.rb
+++ b/app/controllers/api/v1/properties_controller.rb
@@ -1,4 +1,7 @@
 class Api::V1::PropertiesController < ApplicationController
+
+rescue_from NoMethodError, with: :bad_request_error
+
   def index
     facade = PropertiesFacade.new
     if params[:monthly].present?
@@ -16,4 +19,10 @@ class Api::V1::PropertiesController < ApplicationController
     listing = facade.get_listing(params[:id])
     render json: ListingSerializer.new(listing)
   end
+
+  private
+
+    def bad_request_error(exception)
+      render json: ErrorSerializer.new(ErrorMessage.new("Resource not found", 404)).serialize_json, status: :not_found
+    end
 end

--- a/app/poros/error_message.rb
+++ b/app/poros/error_message.rb
@@ -1,0 +1,8 @@
+class ErrorMessage
+  attr_reader :message, :status_code
+
+  def initialize(message, status_code)
+    @message = message
+    @status_code = status_code
+  end
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,16 @@
+class ErrorSerializer
+  def initialize(error_object)
+    @error_object = error_object
+  end
+
+  def serialize_json
+    {
+      errors: [
+        {
+          code: @error_object.status_code,
+          message: @error_object.message
+        }
+      ]
+    }
+  end
+end

--- a/spec/api/v1/properties_request_spec.rb
+++ b/spec/api/v1/properties_request_spec.rb
@@ -82,4 +82,19 @@ describe "oompr search results" do
       expect(listing[:attributes][:photos]).to be_a Array
     end
   end
+
+  describe "sad path" do
+    it "will return a serilaized 404 not found error response if you pass in an id that does not exist", :vcr do
+      get "/api/v1/properties/9999999"
+
+      expect(response).to_not be_successful
+
+      error = JSON.parse(response.body, symbolize_names: true)[:errors][0]
+
+      expect(error).to have_key :code
+      expect(error).to have_key :message
+      expect(error[:code]).to eq(404)
+      expect(error[:message]).to eq("Resource not found")
+    end
+  end
 end

--- a/spec/fixtures/vcr_cassettes/oompr_search_results/sad_path/will_return_a_serilaized_404_not_found_error_response_if_you_pass_in_an_id_that_does_not_exist.yml
+++ b/spec/fixtures/vcr_cassettes/oompr_search_results/sad_path/will_return_a_serilaized_404_not_found_error_response_if_you_pass_in_an_id_that_does_not_exist.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.simplyrets.com/properties/9999999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.10.0
+      Authorization:
+      - Basic c2ltcGx5cmV0czpzaW1wbHlyZXRz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 26 Jul 2024 18:29:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.24.0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT, PATCH, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization
+      Access-Control-Expose-Headers:
+      - X-Total-Count, X-SimplyRETS-LastUpdate, X-SimplyRETS-Media-Type, Link
+      X-Simplyrets-Media-Type:
+      - vnd.simplyrets-v0.1
+      Vary:
+      - Accept, Accept-Language
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"message":"Resource does not exist"}'
+  recorded_at: Fri, 26 Jul 2024 18:29:48 GMT
+recorded_with: VCR 6.2.0

--- a/spec/poros/error_message_spec.rb
+++ b/spec/poros/error_message_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe ErrorMessage do
+  it "exists" do
+    message = "This is an error"
+    status_code = "400"
+
+    error = ErrorMessage.new(message, status_code)
+
+    expect(error).to be_a ErrorMessage
+    expect(error.message).to eq("This is an error")
+    expect(error.status_code).to eq("400")
+  end
+end


### PR DESCRIPTION
The commit message I wrote above pretty much sums it up (error poro and serializer) - really only handled one sad path (passing in a non-existent id for the get single listing endpoint). All other sad paths should just return { "data": [ ] } and I saw that Zach already handled that sad path on the front end!