### PR TITLE
Created POST, DELETE, and GET for favorites resource

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::FavoritesController < ApplicationController
+
+  def create
+    facade = FavoritesFacade.new
+    if params[:user].present? && params[:listing].present?
+      favorite = facade.create_favorite(params[:user], params[:listing])
+      render json: FavoriteSerializer.new(favorite)
+    else
+      render json: ErrorSerializer.new(ErrorMessage.new("Params missing", 400)).serialize_json, status: :bad_request
+    end
+  end
+
+  def index
+    favorites = Favorite.get_all_favorites(params[:user])
+    render json: FavoriteSerializer.new(favorites)
+  end
+
+  def destroy
+    favorite = Favorite.find(params[:id])
+    favorite.destroy
+  end
+end

--- a/app/facades/favorites_facade.rb
+++ b/app/facades/favorites_facade.rb
@@ -1,0 +1,18 @@
+class FavoritesFacade
+  def create_favorite(user, list_id)
+    service = PropertiesService.new
+    listing = service.get_one_listing(list_id)
+    address = format_address(listing)
+
+    Favorite.create(user_id: user, 
+                listing_id: list_id,
+                address: address, 
+                price: listing[:listPrice],
+                picture: listing[:photos][0])
+  end
+
+  def format_address(listing)
+    hash = listing[:address]
+    "#{hash[:full]}, #{hash[:city]}, #{hash[:state]} #{hash[:postalCode]}"
+  end
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,11 @@
+class Favorite < ApplicationRecord
+  validates_presence_of :user_id,
+                        :listing_id,
+                        :picture,
+                        :price,
+                        :address
+
+  def self.get_all_favorites(user)
+    Favorite.select('DISTINCT ON (address) *').where(user_id: user)
+  end
+end

--- a/app/serializers/favorite_serializer.rb
+++ b/app/serializers/favorite_serializer.rb
@@ -1,0 +1,4 @@
+class FavoriteSerializer
+  include JSONAPI::Serializer
+  attributes :user_id, :listing_id, :address, :price, :picture
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :properties, only: [:index, :show]
+      resources :favorites, only: [:index, :create, :destroy]
     end
   end
 end

--- a/db/migrate/20240729212825_create_favorites.rb
+++ b/db/migrate/20240729212825_create_favorites.rb
@@ -1,0 +1,13 @@
+class CreateFavorites < ActiveRecord::Migration[7.1]
+  def change
+    create_table :favorites do |t|
+      t.string :user_id
+      t.string :listing_id
+      t.string :picture
+      t.string :price
+      t.string :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_07_29_212825) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "favorites", force: :cascade do |t|
+    t.string "user_id"
+    t.string "listing_id"
+    t.string "picture"
+    t.string "price"
+    t.string "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/api/v1/favorites_request_spec.rb
+++ b/spec/api/v1/favorites_request_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe "create new favorite" do
+  it "creates a new favorite when given a user id and a listing id", :vcr do
+    post "/api/v1/favorites?user=1&listing=1005172"
+
+    expect(response).to be_successful
+
+    favorite = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(favorite[:type]).to eq("favorite")
+    expect(favorite[:attributes][:user_id]).to eq("1")
+    expect(favorite[:attributes][:listing_id]).to eq("1005172")
+    expect(favorite[:attributes][:address]).to eq("68827 South 99 CT Estates #783, Houston, Texas 77375")
+    expect(favorite[:attributes][:price]).to eq("18730333")
+    expect(favorite[:attributes][:picture]).to eq("https://s3-us-west-2.amazonaws.com/cdn.simplyrets.com/properties/trial/home4.jpg")
+  end
+
+  it "can delete a record" do
+    favorite = Favorite.create(user_id: '1', listing_id: '1', address: '123 Elm Street, Springfield, IL', price: '250000', picture: 'http://example.com/pictures/elm_street.jpg')
+
+    expect(Favorite.count).to eq(1)
+  
+    delete "/api/v1/favorites/#{favorite.id}"
+  
+    expect(response).to be_successful
+    expect(Favorite.count).to eq(0)
+    expect{Favorite.find(favorite.id)}.to raise_error(ActiveRecord::RecordNotFound)
+  end
+  
+  describe "sad path" do
+    it "can't create a favorite unless both params present", :vcr do
+      post "/api/v1/favorites?user=1"
+
+      expect(response).to_not be_successful
+
+      error = JSON.parse(response.body, symbolize_names: true)[:errors][0]
+
+      expect(error[:code]).to eq(400)
+      expect(error[:message]).to eq("Params missing")
+    end
+  end
+
+  describe "get user's favorites" do
+    it "can retrieve a unique list of user's favorites", :vcr do
+      Favorite.create(user_id: '1', listing_id: '1', address: '123 Elm Street, Springfield, IL', price: '250000', picture: 'http://example.com/pictures/elm_street.jpg')
+
+      get "/api/v1/favorites?user=1"
+
+      favorites = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(favorites).to be_a Array
+      expect(favorites[0]).to be_a Hash
+      
+      first = favorites[0]
+
+      expect(first[:type]).to eq("favorite")
+      expect(first[:attributes]).to be_a Hash
+      expect(first[:attributes][:user_id]).to eq("1")
+      expect(first[:attributes][:listing_id]).to be_a String
+      expect(first[:attributes][:address]).to be_a String
+      expect(first[:attributes][:price]).to be_a String
+      expect(first[:attributes][:picture]).to be_a String
+    end
+  end
+end
+

--- a/spec/facades/favorites_facade_spec.rb
+++ b/spec/facades/favorites_facade_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe FavoritesFacade do
+  it "exists" do
+    facade = FavoritesFacade.new
+    expect(facade).to be_a FavoritesFacade
+  end
+
+  it "can create a new favorite entry when passed a user id and liting id", :vcr do
+    facade = FavoritesFacade.new
+    facade.create_favorite("1", "1005172")
+
+    favorite = Favorite.last
+
+    expect(favorite).to be_a Favorite
+    expect(favorite.user_id).to eq("1")
+    expect(favorite.listing_id).to eq("1005172")
+  end
+end

--- a/spec/fixtures/vcr_cassettes/FavoritesFacade/can_create_a_new_favorite_entry_when_passed_a_user_id_and_liting_id.yml
+++ b/spec/fixtures/vcr_cassettes/FavoritesFacade/can_create_a_new_favorite_entry_when_passed_a_user_id_and_liting_id.yml
@@ -1,0 +1,98 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.simplyrets.com/properties/1005172
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.10.0
+      Authorization:
+      - Basic c2ltcGx5cmV0czpzaW1wbHlyZXRz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 30 Jul 2024 00:21:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.24.0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT, PATCH, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization
+      Access-Control-Expose-Headers:
+      - X-Total-Count, X-SimplyRETS-LastUpdate, X-SimplyRETS-Media-Type, Link
+      X-Simplyrets-Media-Type:
+      - vnd.simplyrets-v0.1
+      Vary:
+      - Accept, Accept-Language
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: "{\"privateRemarks\":\"This property is a trial property to test the
+        SimplyRETS. Private agent remarks will be included in this field for use in
+        the SimplyRETS REST API. Lorem ipsum dolor sit amet, consectetur adipiscing
+        elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+        enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+        ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+        est laborum.\",\"showingContactName\":null,\"property\":{\"roof\":\"Aluminum,
+        Composition\",\"cooling\":null,\"style\":\"Ranch\",\"area\":3477,\"bathsFull\":4,\"bathsHalf\":1,\"stories\":3,\"fireplaces\":1,\"flooring\":null,\"heating\":\"Central
+        Furnace,Energy Star,High Efficiency,Fireplace,Humidity Control\",\"bathrooms\":null,\"foundation\":\"Block
+        & Beam\",\"laundryFeatures\":\"Area,Electric Dryer Hookup,Individual Room,Washer
+        Hookup\",\"occupantName\":null,\"ownerName\":null,\"lotDescription\":\"Corner\",\"pool\":\"Community\",\"subType\":\"SingleFamilyResidence\",\"bedrooms\":5,\"interiorFeatures\":\"Drapes/Curtains/Window
+        Cover, Fire/Smoke Alarm, High Ceiling, Prewired for Alarm System\",\"lotSize\":\"50/143X70/163\",\"areaSource\":\"Floorplans\",\"maintenanceExpense\":null,\"additionalRooms\":\"Bonus,Den,Living
+        Room,Main Floor Bedroom\",\"exteriorFeatures\":\"Back Yard Fenced, Covered
+        Patio/Deck, Patio/Deck, Satellite Dish, Storage Shed, Subdivision Tennis Court\",\"water\":null,\"view\":\"Neighborhood\",\"lotSizeArea\":null,\"subdivision\":\"Terranova
+        West Sec 03\",\"construction\":\"Gas & Electric Dryer Hookup,Gas Dryer Hookup,Inside,Individual
+        Room\",\"parking\":{\"leased\":null,\"spaces\":3,\"description\":\"Uncovered,Driveway,Driveway
+        - Concrete,See Remarks\"},\"lotSizeAreaUnits\":null,\"type\":\"RES\",\"garageSpaces\":3.2648817750966175,\"bathsThreeQuarter\":null,\"accessibility\":\"Automatic
+        Gate\",\"acres\":null,\"occupantType\":null,\"subTypeText\":null,\"yearBuilt\":1978},\"mlsId\":1005172,\"showingContactPhone\":null,\"terms\":\"Conventional,Cash,VA
+        Loan,Cash To New Loan\",\"showingInstructions\":\"The showing instructions
+        for this trial property are brought to you by the SimplyRETS team. This field
+        will include any showing remarks for the given listing in your RETS feed.
+        Enjoy!\",\"office\":{\"contact\":{\"email\":\"info-office@example.com\",\"office\":\"(541)
+        682-2997\",\"cell\":null},\"name\":null,\"servingName\":null,\"brokerid\":null},\"leaseTerm\":null,\"disclaimer\":\"This
+        information is believed to be accurate, but without warranty.\",\"specialListingConditions\":null,\"originalListPrice\":null,\"address\":{\"crossStreet\":\"East
+        Katella & Handy Street\",\"state\":\"Texas\",\"country\":\"United States\",\"postalCode\":\"77375\",\"streetName\":\"South
+        99 CT Estates\",\"streetNumberText\":\"68827\",\"city\":\"Houston\",\"streetNumber\":68827,\"full\":\"68827
+        South 99 CT Estates #783\",\"unit\":\"783\"},\"agreement\":\"Exclusive Right
+        To Sell\",\"listDate\":\"2010-01-26T01:51:46.915087Z\",\"agent\":{\"officeMlsId\":null,\"lastName\":\"Mendoza\",\"contact\":{\"email\":\"agent@example.com\",\"office\":\"(541)
+        682-2997\",\"cell\":\"(009) 022-2455\"},\"address\":null,\"modified\":null,\"firstName\":\"Scott\",\"id\":\"smendoza\"},\"modified\":\"2006-03-16T13:48:17.525789Z\",\"school\":{\"middleSchool\":\"Pattison\",\"highSchool\":\"Klein
+        Oak\",\"elementarySchool\":\"Greenwood\",\"district\":null},\"photos\":[\"https://s3-us-west-2.amazonaws.com/cdn.simplyrets.com/properties/trial/home4.jpg\",\"https://s3-us-west-2.amazonaws.com/cdn.simplyrets.com/properties/trial/home-inside-4.jpg\"],\"listPrice\":18730333,\"internetAddressDisplay\":null,\"listingId\":\"59437738\",\"mls\":{\"status\":\"Pending\",\"area\":\"Memorial
+        West\",\"daysOnMarket\":446,\"originalEntryTimestamp\":null,\"originatingSystemName\":null,\"statusText\":\"ÿ\x93\",\"areaMinor\":null},\"internetEntireListingDisplay\":null,\"geo\":{\"county\":\"West\",\"lat\":29.747591,\"lng\":-95.577139,\"marketArea\":\"Memorial
+        West\",\"directions\":\"From 290 exit Barker Cypress to left on Tuckerton,
+        right on Danbury Bridge, right on Bending Post, right on Driftwood Prairie\"},\"tax\":{\"taxYear\":1965,\"taxAnnualAmount\":2326,\"id\":\"870-420-184-4578\"},\"coAgent\":{\"officeMlsId\":null,\"lastName\":null,\"contact\":{\"email\":\"coagent@example.com\",\"office\":\"(024)
+        854-4588\",\"cell\":null},\"address\":null,\"modified\":null,\"firstName\":null,\"id\":\"KWCO834\"},\"sales\":{\"closeDate\":\"1995-09-10T04:19:22.097351Z\",\"office\":{\"contact\":null,\"name\":\"Keller
+        Williams Greater Houston\",\"servingName\":\"Keller Williams Greater Houston\",\"brokerid\":\"KWCO834\"},\"closePrice\":12983889,\"agent\":{\"officeMlsId\":\"KWCO834\",\"lastName\":\"Mullins\",\"contact\":null,\"address\":null,\"modified\":null,\"firstName\":\"Uriel\",\"id\":\"umullins\"},\"contractDate\":null},\"ownership\":null,\"leaseType\":\"Net,Triple
+        Net\",\"virtualTourUrl\":null,\"remarks\":\"This property is a trial property
+        to test the SimplyRETS. This field will include remarks or descriptions from
+        your RETS feed intended for public view. Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+        nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
+        in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+        sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+        anim id est laborum.\",\"association\":{\"frequency\":null,\"fee\":1000,\"name\":\"SimplyRETS
+        Home Owners Association\",\"amenities\":\"Club House,Community Pool,Garden/
+        Greenbelt/ Trails,Playground,Recreation Room,Sauna/ Spa/ Hot Tub\"}}"
+  recorded_at: Tue, 30 Jul 2024 00:21:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/create_new_favorite/creates_a_new_favorite_when_given_a_user_id_and_a_listing_id.yml
+++ b/spec/fixtures/vcr_cassettes/create_new_favorite/creates_a_new_favorite_when_given_a_user_id_and_a_listing_id.yml
@@ -1,0 +1,98 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.simplyrets.com/properties/1005172
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.10.0
+      Authorization:
+      - Basic c2ltcGx5cmV0czpzaW1wbHlyZXRz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 30 Jul 2024 00:29:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.24.0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT, PATCH, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization
+      Access-Control-Expose-Headers:
+      - X-Total-Count, X-SimplyRETS-LastUpdate, X-SimplyRETS-Media-Type, Link
+      X-Simplyrets-Media-Type:
+      - vnd.simplyrets-v0.1
+      Vary:
+      - Accept, Accept-Language
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: "{\"privateRemarks\":\"This property is a trial property to test the
+        SimplyRETS. Private agent remarks will be included in this field for use in
+        the SimplyRETS REST API. Lorem ipsum dolor sit amet, consectetur adipiscing
+        elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+        enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+        ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+        est laborum.\",\"showingContactName\":null,\"property\":{\"roof\":\"Aluminum,
+        Composition\",\"cooling\":null,\"style\":\"Ranch\",\"area\":3477,\"bathsFull\":4,\"bathsHalf\":1,\"stories\":3,\"fireplaces\":1,\"flooring\":null,\"heating\":\"Central
+        Furnace,Energy Star,High Efficiency,Fireplace,Humidity Control\",\"bathrooms\":null,\"foundation\":\"Block
+        & Beam\",\"laundryFeatures\":\"Area,Electric Dryer Hookup,Individual Room,Washer
+        Hookup\",\"occupantName\":null,\"ownerName\":null,\"lotDescription\":\"Corner\",\"pool\":\"Community\",\"subType\":\"SingleFamilyResidence\",\"bedrooms\":5,\"interiorFeatures\":\"Drapes/Curtains/Window
+        Cover, Fire/Smoke Alarm, High Ceiling, Prewired for Alarm System\",\"lotSize\":\"50/143X70/163\",\"areaSource\":\"Floorplans\",\"maintenanceExpense\":null,\"additionalRooms\":\"Bonus,Den,Living
+        Room,Main Floor Bedroom\",\"exteriorFeatures\":\"Back Yard Fenced, Covered
+        Patio/Deck, Patio/Deck, Satellite Dish, Storage Shed, Subdivision Tennis Court\",\"water\":null,\"view\":\"Neighborhood\",\"lotSizeArea\":null,\"subdivision\":\"Terranova
+        West Sec 03\",\"construction\":\"Gas & Electric Dryer Hookup,Gas Dryer Hookup,Inside,Individual
+        Room\",\"parking\":{\"leased\":null,\"spaces\":3,\"description\":\"Uncovered,Driveway,Driveway
+        - Concrete,See Remarks\"},\"lotSizeAreaUnits\":null,\"type\":\"RES\",\"garageSpaces\":3.2648817750966175,\"bathsThreeQuarter\":null,\"accessibility\":\"Automatic
+        Gate\",\"acres\":null,\"occupantType\":null,\"subTypeText\":null,\"yearBuilt\":1978},\"mlsId\":1005172,\"showingContactPhone\":null,\"terms\":\"Conventional,Cash,VA
+        Loan,Cash To New Loan\",\"showingInstructions\":\"The showing instructions
+        for this trial property are brought to you by the SimplyRETS team. This field
+        will include any showing remarks for the given listing in your RETS feed.
+        Enjoy!\",\"office\":{\"contact\":{\"email\":\"info-office@example.com\",\"office\":\"(541)
+        682-2997\",\"cell\":null},\"name\":null,\"servingName\":null,\"brokerid\":null},\"leaseTerm\":null,\"disclaimer\":\"This
+        information is believed to be accurate, but without warranty.\",\"specialListingConditions\":null,\"originalListPrice\":null,\"address\":{\"crossStreet\":\"East
+        Katella & Handy Street\",\"state\":\"Texas\",\"country\":\"United States\",\"postalCode\":\"77375\",\"streetName\":\"South
+        99 CT Estates\",\"streetNumberText\":\"68827\",\"city\":\"Houston\",\"streetNumber\":68827,\"full\":\"68827
+        South 99 CT Estates #783\",\"unit\":\"783\"},\"agreement\":\"Exclusive Right
+        To Sell\",\"listDate\":\"2010-01-26T01:51:46.915087Z\",\"agent\":{\"officeMlsId\":null,\"lastName\":\"Mendoza\",\"contact\":{\"email\":\"agent@example.com\",\"office\":\"(541)
+        682-2997\",\"cell\":\"(009) 022-2455\"},\"address\":null,\"modified\":null,\"firstName\":\"Scott\",\"id\":\"smendoza\"},\"modified\":\"2006-03-16T13:48:17.525789Z\",\"school\":{\"middleSchool\":\"Pattison\",\"highSchool\":\"Klein
+        Oak\",\"elementarySchool\":\"Greenwood\",\"district\":null},\"photos\":[\"https://s3-us-west-2.amazonaws.com/cdn.simplyrets.com/properties/trial/home4.jpg\",\"https://s3-us-west-2.amazonaws.com/cdn.simplyrets.com/properties/trial/home-inside-4.jpg\"],\"listPrice\":18730333,\"internetAddressDisplay\":null,\"listingId\":\"59437738\",\"mls\":{\"status\":\"Pending\",\"area\":\"Memorial
+        West\",\"daysOnMarket\":446,\"originalEntryTimestamp\":null,\"originatingSystemName\":null,\"statusText\":\"ÿ\x93\",\"areaMinor\":null},\"internetEntireListingDisplay\":null,\"geo\":{\"county\":\"West\",\"lat\":29.747591,\"lng\":-95.577139,\"marketArea\":\"Memorial
+        West\",\"directions\":\"From 290 exit Barker Cypress to left on Tuckerton,
+        right on Danbury Bridge, right on Bending Post, right on Driftwood Prairie\"},\"tax\":{\"taxYear\":1965,\"taxAnnualAmount\":2326,\"id\":\"870-420-184-4578\"},\"coAgent\":{\"officeMlsId\":null,\"lastName\":null,\"contact\":{\"email\":\"coagent@example.com\",\"office\":\"(024)
+        854-4588\",\"cell\":null},\"address\":null,\"modified\":null,\"firstName\":null,\"id\":\"KWCO834\"},\"sales\":{\"closeDate\":\"1995-09-10T04:19:22.097351Z\",\"office\":{\"contact\":null,\"name\":\"Keller
+        Williams Greater Houston\",\"servingName\":\"Keller Williams Greater Houston\",\"brokerid\":\"KWCO834\"},\"closePrice\":12983889,\"agent\":{\"officeMlsId\":\"KWCO834\",\"lastName\":\"Mullins\",\"contact\":null,\"address\":null,\"modified\":null,\"firstName\":\"Uriel\",\"id\":\"umullins\"},\"contractDate\":null},\"ownership\":null,\"leaseType\":\"Net,Triple
+        Net\",\"virtualTourUrl\":null,\"remarks\":\"This property is a trial property
+        to test the SimplyRETS. This field will include remarks or descriptions from
+        your RETS feed intended for public view. Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+        nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
+        in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+        sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+        anim id est laborum.\",\"association\":{\"frequency\":null,\"fee\":1000,\"name\":\"SimplyRETS
+        Home Owners Association\",\"amenities\":\"Club House,Community Pool,Garden/
+        Greenbelt/ Trails,Playground,Recreation Room,Sauna/ Spa/ Hot Tub\"}}"
+  recorded_at: Tue, 30 Jul 2024 00:29:38 GMT
+recorded_with: VCR 6.2.0

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Favorite, type: :model do
+  describe "validations" do
+    it { should validate_presence_of :user_id }
+    it { should validate_presence_of :listing_id }
+    it { should validate_presence_of :address }
+    it { should validate_presence_of :price }
+    it { should validate_presence_of :picture }
+  end
+
+  describe "get_all_favorites" do
+    it "should get all favorites with a distinct address when passed a user_id" do
+      favorite1 = Favorite.create(user_id: '1', listing_id: '1', address: '123 Elm Street, Springfield, IL', price: '250000', picture: 'http://example.com/pictures/elm_street.jpg')
+      favorite2 = Favorite.create(user_id: '1', listing_id: '2', address: '456 Oak Avenue, Springfield, IL', price: '350000', picture: 'http://example.com/pictures/oak_avenue.jpg')
+      favorite3 = Favorite.create(user_id: '1', listing_id: '3', address: '789 Maple Road, Springfield, IL', price: '275000', picture: 'http://example.com/pictures/maple_road.jpg')
+      favorite4 = Favorite.create(user_id: '1', listing_id: '3', address: '789 Maple Road, Springfield, IL', price: '275000', picture: 'http://example.com/pictures/maple_road.jpg')
+
+      favorites = Favorite.get_all_favorites('1')
+
+      expect(favorites).to eq([favorite1, favorite2, favorite3])
+    end
+  end
+end


### PR DESCRIPTION
Here's the format for making api calls to the backend re: favorites
(I'll also post this in slack)

Create a new favorite:
POST http://localhost:3000/api/v1/favorites?user=#{current_user's id}&listing=#{listing you clicked heart on}
-- I made it so both params are required, it returns a 400 bad request "params missing" error json response if you don't have both

Delete a favorite record:
DELETE http://localhost:3000/api/v1/favorites/#{the id number passed to you from the backend}
--So on this one, you're going to have to include the top level [:id] number that comes back in the json response somewhere in your favorite PORO, so then when you enter it in a delete request it will delete the correct entry. Make sure you don't pass the user_id or listing_id

Get all favorites for a specific user:
GET http://localhost:3000/api/v1/favorites?user=#{current user's id}
--This ones pretty straight ahead - just grabbing the id from the user of the current session